### PR TITLE
Add spec file for building tendrl-alerting

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include LICENSE
 include AUTHORS
 include ChangeLog
+include requirements.txt
+include tendrl-alerting.service
 exclude .gitignore
 exclude .gitreview
 graft systemd

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include AUTHORS
 include ChangeLog
 include requirements.txt
 include tendrl-alerting.service
+include version.py
 exclude .gitignore
 exclude .gitreview
 graft systemd

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=tendrl-alerting
 VERSION := $(shell PYTHONPATH=. python -c \
-             'import tendrl.alerting; print tendrl.alerting.__version__' \
+             'import version; print version.__version__' \
              | sed 's/\.dev[0-9]*//')
 RELEASE=1
 COMMIT := $(shell git rev-parse HEAD)
@@ -31,7 +31,7 @@ gitversion:
 	# Set version and release to the latest values from Git
 	$(eval VERSION := $(VERSION).dev$(GIT_RELEASE))
 	$(eval RELEASE := $(GIT_RELEASE).$(SHORTCOMMIT))
-	sed -i tendrl/alerting/__init__.py \
+	sed -i version.py \
 	  -e "s/^__version__ = .*/__version__ = '$(VERSION)'/"
 	sed -i tendrl-alerting.spec \
 	  -e "s/^Version: .*/Version: $(VERSION)/"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+NAME=tendrl-alerting
+VERSION := $(shell PYTHONPATH=. python -c \
+             'import tendrl.alerting; print tendrl.alerting.__version__' \
+             | sed 's/\.dev[0-9]*//')
+RELEASE=1
+COMMIT := $(shell git rev-parse HEAD)
+SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
+GIT_RELEASE := $(shell git describe --tags --match 'v*' \
+                 | sed 's/^v//' \
+                 | sed 's/^[^-]*-//' \
+                 | sed 's/-.*//')
+
+all: srpm
+
+clean:
+	rm -rf dist/
+	rm -rf $(NAME)-$(VERSION).tar.gz
+	rm -rf $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm
+
+dist:
+	python setup.py sdist \
+	  && mv dist/$(NAME)-$(VERSION).tar.gz .
+
+srpm: dist
+	fedpkg --dist epel7 srpm
+
+rpm: dist
+	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm --resultdir=. --define "dist .el7"
+
+gitversion:
+	# Set version and release to the latest values from Git
+	$(eval VERSION := $(VERSION).dev$(GIT_RELEASE))
+	$(eval RELEASE := $(GIT_RELEASE).$(SHORTCOMMIT))
+	sed -i tendrl/alerting/__init__.py \
+	  -e "s/^__version__ = .*/__version__ = '$(VERSION)'/"
+	sed -i tendrl-alerting.spec \
+	  -e "s/^Version: .*/Version: $(VERSION)/"
+	sed -i tendrl-alerting.spec \
+	  -e "s/^Release: .*/Release: $(RELEASE)/"
+
+snapshot: gitversion srpm
+
+
+.PHONY: dist rpm srpm gitversion snapshot

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,115 @@
+import re
+from setuptools import Command
 from setuptools import find_packages
 from setuptools import setup
+import subprocess
+try:
+    # Python 2 backwards compat
+    from __builtin__ import raw_input as input
+except ImportError:
+    pass
+
+
+def extract_requirements(filename):
+    with open(filename, 'r') as requirements_file:
+        return [
+            x[:-1] for x in requirements_file.readlines()
+            if not x.startswith("#") and x[:-1] != ''
+        ]
+
+install_requires = extract_requirements('requirements.txt')
+
+
+def read_module_contents():
+    with open('tendrl/alerting/__init__.py') as app_init:
+        return app_init.read()
+
+
+def read_spec_contents():
+    with open('tendrl-alerting.spec') as spec:
+        return spec.read()
+
+module_file = read_module_contents()
+metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
+version = metadata['version']
+
+
+class BumpVersionCommand(Command):
+    """Bump the __version__ number and commit all changes."""
+
+    user_options = [('version=', 'v', 'version number to use')]
+
+    def initialize_options(self):
+        new_version = metadata['version'].split('.')
+        new_version[-1] = str(int(new_version[-1]) + 1)  # Bump the final part
+        self.version = ".".join(new_version)
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+
+        print('old version: %s  new version: %s' %
+              (metadata['version'], self.version))
+        try:
+            input('Press enter to confirm, or ctrl-c to exit >')
+        except KeyboardInterrupt:
+            raise SystemExit("\nNot proceeding")
+
+        old = "__version__ = '%s'" % metadata['version']
+        new = "__version__ = '%s'" % self.version
+        module_file = read_module_contents()
+        with open('tendrl/alerting/__init__.py', 'w') as fileh:
+            fileh.write(module_file.replace(old, new))
+
+        old = 'Version: %s' % metadata['version']
+        new = 'Version: %s' % self.version
+        spec_file = read_spec_contents()
+        with open('tendrl-alerting.spec', 'w') as fileh:
+            fileh.write(spec_file.replace(old, new))
+
+        # Commit everything with a standard commit message
+        cmd = ['git', 'commit', '-a', '-m', 'version %s' % self.version]
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+
+class ReleaseCommand(Command):
+    """Tag and push a new release."""
+
+    user_options = [('sign', 's', 'GPG-sign the Git tag and release files')]
+
+    def initialize_options(self):
+        self.sign = False
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        # Create Git tag
+        tag_name = 'v%s' % version
+        cmd = ['git', 'tag', '-a', tag_name, '-m', 'version %s' % version]
+        if self.sign:
+            cmd.append('-s')
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+        # Push Git tag to origin remote
+        cmd = ['git', 'push', 'origin', tag_name]
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+        # Push package to pypi
+        # cmd = ['python', 'setup.py', 'sdist', 'upload']
+        # if self.sign:
+        #    cmd.append('--sign')
+        # print(' '.join(cmd))
+        # subprocess.check_call(cmd)
+
 
 setup(
     name="tendrl-alerting",
-    version="1.1",
+    version=version,
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*",
                                     "tests"]),
     namespace_packages=['tendrl'],
@@ -12,10 +118,12 @@ setup(
     author_email="rkanade@redhat.com",
     license="LGPL-2.1+",
     zip_safe=False,
+    install_requires=install_requires,
     entry_points={
         'console_scripts': ['tendrl-alerting = '
                             'tendrl.alerting.manager'
                             ':main'
                             ]
-    }
+    },
+    cmdclass={'bumpversion': BumpVersionCommand, 'release': ReleaseCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 def extract_requirements(filename):
     with open(filename, 'r') as requirements_file:
         return [
-            x[:-1] for x in requirements_file.readlines()
+            x.strip() for x in requirements_file.readlines()
             if not x.startswith("#") and x[:-1] != ''
         ]
 
@@ -21,7 +21,7 @@ install_requires = extract_requirements('requirements.txt')
 
 
 def read_module_contents():
-    with open('tendrl/alerting/__init__.py') as app_init:
+    with open('version.py') as app_init:
         return app_init.read()
 
 
@@ -59,7 +59,7 @@ class BumpVersionCommand(Command):
         old = "__version__ = '%s'" % metadata['version']
         new = "__version__ = '%s'" % self.version
         module_file = read_module_contents()
-        with open('tendrl/alerting/__init__.py', 'w') as fileh:
+        with open('version.py', 'w') as fileh:
             fileh.write(module_file.replace(old, new))
 
         old = 'Version: %s' % metadata['version']

--- a/tendrl-alerting.service
+++ b/tendrl-alerting.service
@@ -3,9 +3,9 @@ Description= Daemon to manage tendrl notifications
 
 [Service]
 Type=simple
+Environment="HOME=/var/lib/tendrl"
 ExecStart=/usr/bin/tendrl-alerting
 ExecReload=/bin/kill -HUP $MAINPID
-KillMode=process
 Restart=on-failure
 PrivateTmp=true
 

--- a/tendrl-alerting.service
+++ b/tendrl-alerting.service
@@ -1,0 +1,13 @@
+[Unit]
+Description= Daemon to manage tendrl notifications
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/tendrl-alerting
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/tendrl-alerting.spec
+++ b/tendrl-alerting.spec
@@ -1,0 +1,74 @@
+Name: tendrl-alerting
+Version: 1.1
+Release: 1%{?dist}
+BuildArch: noarch
+Summary: Module for Tendrl Alerting
+Source0: %{name}-%{version}.tar.gz
+License: LGPLv2+
+URL: https://github.com/Tendrl/alerting
+
+BuildRequires: python-gevent
+BuildRequires: pytest
+BuildRequires: systemd
+BuildRequires: python-mock
+
+Requires: python-etcd
+Requires: python-dateutil
+Requires: gevent
+Requires: python-greenlet
+Requires: msgpack-python
+Requires: pytz
+Requires: flask
+Requires: Flask-API
+
+%description
+Python module for Tendrl alerting
+
+%prep
+%setup
+
+# Remove bundled egg-info
+rm -rf %{name}.egg-info
+
+%build
+%{__python} setup.py build
+
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
+
+%install
+%{__python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+install -m  0755  --directory $RPM_BUILD_ROOT%{_var}/log/tendrl/alerting
+install -m  0755  --directory $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/alerting
+install -m  0755  --directory $RPM_BUILD_ROOT%{_datadir}/tendrl/alerting
+install -Dm 0644 tendrl-alerting.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-alerting.service
+install -Dm 0644 etc/tendrl/tendrl.conf.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/tendrl.conf
+install -Dm 0644 etc/logging.yaml.timedrotation.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/alerting_logging.yaml
+install -Dm 644 etc/*.sample $RPM_BUILD_ROOT%{_datadir}/tendrl/alerting/.
+
+%post
+%systemd_post tendrl-alerting.service
+
+%preun
+%systemd_preun tendrl-alerting.service
+
+%postun
+%systemd_postun_with_restart tendrl-alerting.service
+
+%check
+py.test -v tendrl/alerting/tests || :
+
+%files -f INSTALLED_FILES
+%dir %{_var}/log/tendrl/alerting
+%dir %{_sysconfdir}/tendrl/alerting
+%dir %{_datadir}/tendrl/alerting
+%doc README.rst
+%license LICENSE
+%{_datadir}/tendrl/alerting/
+%{_sysconfdir}/tendrl/tendrl.conf
+%{_sysconfdir}/tendrl/alerting_logging.yaml
+%{_unitdir}/tendrl-alerting.service
+
+%changelog
+* Tue Nov 01 2016 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 0.0.1-1
+- Initial build.

--- a/tendrl-alerting.spec
+++ b/tendrl-alerting.spec
@@ -1,5 +1,5 @@
 Name: tendrl-alerting
-Version: 1.1
+Version: 1.2
 Release: 1%{?dist}
 BuildArch: noarch
 Summary: Module for Tendrl Alerting
@@ -12,14 +12,13 @@ BuildRequires: pytest
 BuildRequires: systemd
 BuildRequires: python-mock
 
-Requires: python-etcd
+Requires: python-flask
 Requires: python-dateutil
-Requires: gevent
-Requires: python-greenlet
-Requires: msgpack-python
+Requires: python-etcd
+Requires: python-six
 Requires: pytz
-Requires: flask
-Requires: Flask-API
+Requires: PyYAML
+Requires: tendrl-commons
 
 %description
 Python module for Tendrl alerting
@@ -42,8 +41,9 @@ install -m  0755  --directory $RPM_BUILD_ROOT%{_var}/log/tendrl/alerting
 install -m  0755  --directory $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/alerting
 install -m  0755  --directory $RPM_BUILD_ROOT%{_datadir}/tendrl/alerting
 install -Dm 0644 tendrl-alerting.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-alerting.service
-install -Dm 0644 etc/tendrl/tendrl.conf.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/tendrl.conf
-install -Dm 0644 etc/logging.yaml.timedrotation.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/alerting_logging.yaml
+install -Dm 0644 etc/tendrl/alerting.conf.yaml.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/alerting/alerting.conf.yaml
+install -Dm 0644 etc/tendrl/alerting_logging.yaml.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/alerting/alerting_logging.yaml
+install -Dm 0644 etc/tendrl/email.conf.yaml.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/alerting/email.conf.yaml
 install -Dm 644 etc/*.sample $RPM_BUILD_ROOT%{_datadir}/tendrl/alerting/.
 
 %post
@@ -65,10 +65,11 @@ py.test -v tendrl/alerting/tests || :
 %doc README.rst
 %license LICENSE
 %{_datadir}/tendrl/alerting/
-%{_sysconfdir}/tendrl/tendrl.conf
-%{_sysconfdir}/tendrl/alerting_logging.yaml
+%{_sysconfdir}/tendrl/alerting/alerting.conf.yaml
+%{_sysconfdir}/tendrl/alerting/alerting_logging.yaml
+%{_sysconfdir}/tendrl/alerting/email.conf.yaml
 %{_unitdir}/tendrl-alerting.service
 
 %changelog
-* Tue Nov 01 2016 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 0.0.1-1
+* Tue Mar 07 2017 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 1.2-1
 - Initial build.

--- a/tendrl/alerting/__init__.py
+++ b/tendrl/alerting/__init__.py
@@ -1,5 +1,3 @@
-__version__ = '1.2'
-
 try:
     from gevent import monkey
 except ImportError:


### PR DESCRIPTION
This path does the following things:
1) Update MANIFEST.in with the required file details
2) Update setup.py to bump version
3) Add Makefile and spec file for build this package
4) Add service file to start the tendrl-alerting service

tendrl-bug-id: Tendrl/alerting#27
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>