### PR TITLE
improve configuration of setuptools, tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,6 @@ script:
 env:
   - TOXENV=pep8
   - TOXENV=check_commit_msg
-  - TOXENV=cover
+  - TOXENV=py27-cover-master
+  - TOXENV=py27-cover-develop
   - TOXENV=docs

--- a/requirements.develop.txt
+++ b/requirements.develop.txt
@@ -1,0 +1,3 @@
+# use latest version from develop branch on github
+git+https://github.com/Tendrl/commons.git@develop
+-e .

--- a/requirements.master.txt
+++ b/requirements.master.txt
@@ -1,0 +1,3 @@
+# use latest version from master branch on github
+git+https://github.com/Tendrl/commons.git@master
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# The order of packages is significant, because pip processes them in the order
-# of appearance. Changing the order has an impact on the overall integration
-# process, which may cause wedges in the gate later.
-
-python-etcd

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,14 @@ setup(
     author_email="rkanade@redhat.com",
     license="LGPL-2.1+",
     zip_safe=False,
+    install_requires=[
+        "PyYAML",
+        "gevent>=1.0",
+        "namespaces",
+        "python-etcd",
+        "six",
+        "tendrl-commons",
+        ],
     entry_points={
         'console_scripts': ['tendrl-alerting = '
                             'tendrl.alerting.manager'

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@
 
 [tox]
 minversion = 2.0
-envlist = py34,py27,pypy,pep8
+# envlist = {py26,py27,py34}-{master,develop},pep8,docs
+envlist = py27-{master,develop},pep8,docs
 
 # Test env defaults, runs unit tests via pytest.
 # In this case, the "default" means that py34, py27 or other test enviroment
@@ -13,29 +14,27 @@ envlist = py34,py27,pypy,pep8
 # Uncomment the previous line when you need to speedup unit tests setup
 # during development, it would disable sdist build (it sets skipsdist = true)
 # and install the project in devel mode (pip install -e .).
+passenv =
+    cover: TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     pytest
     mock
-commands = py.test tendrl
+    coverage
+    pytest-cov
+    cover: codecov
+    master: -r{toxinidir}/requirements.master.txt
+    develop: -r{toxinidir}/requirements.develop.txt
+commands =
+    python -m pytest --cov=tendrl tendrl/alerting/tests
+    cover: codecov
 
 # Runs PEP8 checks on the source code via flake8 tool
 [testenv:pep8]
 skip_install = true
-deps = flake8
-commands = flake8 tendrl
-
-# Runs py.test unit tests with codecov.io code coverage report
-# used by Travis CI (see .travis.yml)
-[testenv:cover]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
-    pytest
-    pytest-cov
-    coverage
-    codecov
-commands =
-    py.test --cov=tendrl tendrl/alerting/tests
-    codecov
+    flake8
+    hacking
+commands = flake8 tendrl
 
 # Runs check_commit_msg.py script (used by Travis CI, see .travis.yml)
 [testenv:check_commit_msg]
@@ -74,4 +73,4 @@ exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build
 [pytest]
 # pytest configuration
 # see: http://docs.pytest.org/en/latest/customize.html#adding-default-options
-addopts = -v
+# addopts = -v


### PR DESCRIPTION
This pull request updates tendrl-alerting based on improvements added into tendrl-commons recently.

Quick summary:

* I moved requirements.txt into install_requires of setup.py, while keeping requirements.txt files for CI/development purposes, see https://caremad.io/posts/2013/07/setup-vs-requirement/ for explanation.
* I updated tox.ini consolidating multiple test environments into single description
* I updated Travis CI configuration, it runs py27-cover-{master,develop} environments now. We could enable py26 and py34 again when issues with these are fixed in tendrl-commons.

tendrl-bug-id: Tendrl/alerting#37